### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # SteveAI
+# python 3.7 or higher


### PR DESCRIPTION
From Python 3.6 onwards, the standard dict type maintains insertion order by default.
